### PR TITLE
Add initial migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /public/storage
 /storage/*.key
 /vendor
-.env
+.env*
 .env.backup
 .env.production
 .phpactor.json

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Competition extends Model
+{
+    /** @use HasFactory<\Database\Factories\CompetitionFactory> */
+    use HasFactory, Uuid;
+
+    protected $fillable = [
+        'name',
+        'type',
+    ];
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Event extends Model
+{
+    /** @use HasFactory<\Database\Factories\EventFactory> */
+    use HasFactory, Uuid;
+
+    protected $fillable = [
+        'game_id',
+        'player_id',
+        'team_id',
+        'event_type',
+        'minute',
+        'description'
+    ];
+}

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Game extends Model
+{
+    /** @use HasFactory<\Database\Factories\GameFactory> */
+    use HasFactory, Uuid;
+}

--- a/app/Models/Player.php
+++ b/app/Models/Player.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+use App\Traits\Uuid;
+
+class Player extends Model
+{
+    /** @use HasFactory<\Database\Factories\PlayerFactory> */
+    use HasFactory, Uuid;
+
+    protected $fillable = [
+        'name',
+        'birthdate',
+        'team_id',
+    ];
+}

--- a/app/Models/PlayerGame.php
+++ b/app/Models/PlayerGame.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PlayerGame extends Model
+{
+    /** @use HasFactory<\Database\Factories\PlayerGameFactory> */
+    use HasFactory;
+    
+    protected $fillable = [
+        'game_id',
+        'player_id',
+    ];
+
+    public $incrementing = false;  // No auto-incrementing ID
+    protected $primaryKey = ['game_id', 'player_id'];  // Composite primary key
+}

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Result extends Model
+{
+    /** @use HasFactory<\Database\Factories\ResultFactory> */
+    use HasFactory, Uuid;
+
+    protected $fillable = [
+        'game_id',
+        'home_team_id',
+        'away_team_id',
+        'home_score',
+        'away_score',
+    ];
+}

--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Season extends Model
+{
+    /** @use HasFactory<\Database\Factories\SeasonFactory> */
+    use HasFactory, Uuid;
+
+    protected $fillable = [
+        'year',
+    ];
+}

--- a/app/Models/SeasonCompetition.php
+++ b/app/Models/SeasonCompetition.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SeasonCompetition extends Model
+{
+    /** @use HasFactory<\Database\Factories\SeasonCompetitionFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'season_id',
+        'competition_id',
+        'team_id',
+    ];
+
+    public $incrementing = false;  // No auto-incrementing ID
+    protected $primaryKey = ['season_id', 'competition_id', 'team_id'];  // Composite primary key
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    /** @use HasFactory<\Database\Factories\TeamFactory> */
+    use HasFactory, Uuid;
+
+    protected $fillable = [
+        'name',
+        'founded'
+    ];
+
+    public function players()
+    {
+        return $this->hasMany(Player::class);
+    }
+}

--- a/app/Traits/Uuid.php
+++ b/app/Traits/Uuid.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Str;
+
+trait Uuid {
+    protected static function boot() {
+        parent::boot();
+        static::creating(function ($model) {
+            $model->id = (string)Str::uuid();
+        });
+    }
+    public function getIncrementing(): bool {
+        return false;
+    }
+    public function getKeyType(): string {
+        return 'string';
+    }
+}

--- a/database/migrations/2024_10_13_130556_create_teams_table.php
+++ b/database/migrations/2024_10_13_130556_create_teams_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->string('name')->unique();
+            $table->date('founded')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/database/migrations/2024_10_13_133558_create_players_table.php
+++ b/database/migrations/2024_10_13_133558_create_players_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('players', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('team_id')->constrained()->nullable()->onDelete('cascade');
+
+            $table->string('name');
+            $table->date('birthdate')->nullable();
+            
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('players');
+    }
+};

--- a/database/migrations/2024_10_13_135400_create_competitions_table.php
+++ b/database/migrations/2024_10_13_135400_create_competitions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('competitions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->string('name')->unique();
+            $table->string('type');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('competitions');
+    }
+};

--- a/database/migrations/2024_10_13_135522_create_seasons_table.php
+++ b/database/migrations/2024_10_13_135522_create_seasons_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('seasons', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->string('year');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('seasons');
+    }
+};

--- a/database/migrations/2024_10_13_136428_create_season_competitions_table.php
+++ b/database/migrations/2024_10_13_136428_create_season_competitions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('season_competitions', function (Blueprint $table) {
+            $table->foreignUuid('team_id')->constrained()->onDelete('cascade');
+            $table->foreignUuid('competition_id')->constrained()->onDelete('cascade');
+            $table->foreignUuid('season_id')->constrained()->onDelete('cascade');
+
+            $table->primary(['team_id', 'competition_id', 'season_id']);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('season_competitions');
+    }
+};

--- a/database/migrations/2024_10_13_181530_create_games_table.php
+++ b/database/migrations/2024_10_13_181530_create_games_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('games', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            
+            $table->foreignUuid('season_id')->constrained()->onDelete('cascade');
+            $table->foreignUuid('competition_id')->constrained()->onDelete('cascade');
+
+            $table->dateTime('date')->nullable();
+            $table->string('location')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('games');
+    }
+};

--- a/database/migrations/2024_10_13_182530_create_results_table.php
+++ b/database/migrations/2024_10_13_182530_create_results_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('results', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('game_id')->constrained()->onDelete('cascade');;
+            $table->foreignUuid('home_team_id')->constrained('teams')->onDelete('cascade');;
+            $table->foreignUuid('away_team_id')->constrained('teams')->onDelete('cascade');;
+            
+            $table->unsignedTinyInteger('home_score')->nullable();
+            $table->unsignedTinyInteger('away_score')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('results');
+    }
+};

--- a/database/migrations/2024_10_13_185933_create_player_games_table.php
+++ b/database/migrations/2024_10_13_185933_create_player_games_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('player_games', function (Blueprint $table) {
+            $table->foreignUuid('game_id')->constrained()->onDelete('cascade');
+            $table->foreignUuid('player_id')->constrained()->onDelete('cascade');
+
+            // Composite primary key using both game_id and player_id
+            $table->primary(['game_id', 'player_id']);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('player_games');
+    }
+};

--- a/database/migrations/2024_10_15_103859_create_events_table.php
+++ b/database/migrations/2024_10_15_103859_create_events_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('game_id')->constrained()->onDelete('cascade');
+            $table->foreignUuid('player_id')->nullable()->constrained()->onDelete('cascade');
+            $table->foreignUuid('team_id')->nullable()->constrained()->onDelete('cascade');
+
+            $table->string('event_type');
+            $table->unsignedSmallInteger('minute')->nullable();
+            $table->string('description')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -10,12 +10,5 @@ class DatabaseSeeder extends Seeder
      * Seed the application's database.
      */
     public function run(): void
-    {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
-    }
+    {}
 }


### PR DESCRIPTION
### Description

This pull request adds the necessary migrations based on the provided [DBML schema](https://dbdiagram.io/d/hora-d-play-670bb8b897a66db9a3cca2fb). The migrations will establish the database structure required for the 'Hora d Play' app, facilitating proper management of competitions, teams, seasons, games, and events. Key entities like competitions, seasons, teams, and events are modeled as outlined in the DBML diagram to ensure data consistency and easy querying.

### Changes Implemented

- **Created migrations for the following tables:**
  1. **competitions:** Handles details of various competitions.
  2. **seasons:** Stores season data and links to competitions.
  3. **teams:** Stores team information.
  4. **games:** Holds game-specific information such as game date, participating teams, location of the game,
  5. **results** Holds the game's score,
  6. **events:** Records events like goals, cards, and other match occurrences.
  7. **players** Records player information

- **Relationships:** The migrations define foreign key relationships between competitions, seasons, teams, and games, following the structure defined in the DBML schema. For example, each game is associated with a specific season and competition.