### PR TITLE
Implement GET /games/:game_id route and add broadcast game-live.game_id channel

### DIFF
--- a/app/Events/GameUpdated.php
+++ b/app/Events/GameUpdated.php
@@ -33,7 +33,8 @@ class GameUpdated implements ShouldBroadcastNow
     public function broadcastOn(): array
     {
         return [
-            new Channel('game-live'),
+            new Channel('games-live'),
+            new Channel('game-live.' . $this->game_event->game_id),
         ];
     }
 
@@ -47,14 +48,5 @@ class GameUpdated implements ShouldBroadcastNow
         return [
             'game_event' => $this->game_event,
         ];
-    }
-
-    /**
-     * Determine if the event should be broadcast.
-     */
-    public function broadcastWhen(): bool
-    {
-        // Broadcast only when the event type is 'goal'
-        return $this->game_event->event_type === 'goal';
     }
 }

--- a/app/Http/Controllers/GameController.php
+++ b/app/Http/Controllers/GameController.php
@@ -26,4 +26,14 @@ class GameController extends Controller
 
         return response()->json($formattedGames);
     }
+
+    public function get_one(string $game_id): JsonResponse {
+        $game = $this->game_repository_interface->get_one($game_id);
+
+        if (is_null($game)) {
+            return response()->json(['message' => "Game's id not found"], 404);
+        }
+
+        return response()->json($game);
+    }
 }

--- a/app/Interfaces/GameRepositoryInterface.php
+++ b/app/Interfaces/GameRepositoryInterface.php
@@ -5,4 +5,5 @@ namespace App\Interfaces;
 interface GameRepositoryInterface
 {
     public function index(string $date);
+    public function get_one(string $game);
 }

--- a/app/Repositories/GameEventRepository.php
+++ b/app/Repositories/GameEventRepository.php
@@ -11,6 +11,8 @@ class GameEventRepository implements GameEventRepositoryInterface
     public function index($game_id) {
         $events = Event::with(['team', 'player'])
             ->where('game_id', $game_id)
+            ->orderBy('minute')
+            ->orderBy('created_at')
             ->get(['event_type', 'minute', 'team_id', 'player_id']);
 
         return $events->map(function ($event) {

--- a/app/Repositories/GameRepository.php
+++ b/app/Repositories/GameRepository.php
@@ -62,4 +62,48 @@ class GameRepository implements GameRepositoryInterface
 
         return $games;
     }
+
+    public function get_one(string $game_id) {
+        $game = collect(DB::select("
+            SELECT
+                c.id AS competition_id,
+                c.name AS competition_name,
+                g.id,
+                g.date,
+                g.location,
+                ht.id AS home_team_id,
+                ht.name AS home_team_name,
+                at.id AS away_team_id,
+                at.name AS away_team_name,
+                r.home_score,
+                r.away_score,
+                EXISTS(
+                    SELECT 1 FROM 
+                    events e 
+                    WHERE e.game_id = g.id AND e.event_type = '" . EventType::INITIAL_WHISTLE->value . "'
+                ) AS started,
+                EXISTS(
+                    SELECT 1 FROM events e
+                    WHERE e.game_id = g.id AND e.event_type = '" . EventType::INITIAL_WHISTLE->value . "'
+                ) AND NOT EXISTS (
+                    SELECT 1 FROM events e
+                    WHERE e.game_id = g.id AND e.event_type = '" . EventType::FINAL_WHISTLE->value . "'
+                ) AS ongoing,
+                EXISTS(
+                    SELECT 1 FROM events e 
+                    WHERE e.game_id = g.id AND e.event_type = '" . EventType::FINAL_WHISTLE->value . "'
+                ) AS finished
+            FROM
+                games g
+            JOIN results r ON g.id = r.game_id
+            JOIN teams ht ON r.home_team_id = ht.id
+            JOIN teams at ON r.away_team_id = at.id
+            JOIN season_competitions sc ON r.home_team_id = sc.team_id
+            JOIN competitions c ON sc.competition_id = c.id
+            WHERE
+                g.id = ?;
+        ", [$game_id]))->first();
+
+        return $game;
+    } 
 }

--- a/app/Traits/DatabaseSeederTrait.php
+++ b/app/Traits/DatabaseSeederTrait.php
@@ -17,184 +17,141 @@ use Carbon\Carbon;
 trait DatabaseSeederTrait {
     protected function seed_competitions_and_teams() {
         $competition_teams = [
-            "Campeonato de São Vicente" => [
-                "Mindelenese",
+            "Campeonato de São Vicente - 1ª Divisão" => [
+                "Mindelense",
                 "Derby",
-                "Academica",
+                "Académica do Mindelo",
                 "Batuque",
                 "Amarante",
+                "Farense",
+                "Castilho",
+                "Salamansa",
             ],
-            "Liga Portuguesa" => [
-                "Benfica",
-                "Porto",
-                "Sporting",
-                "Sporting Braga",
-                "Belenenses",
+            "Campeonato de São Vicente - 2ª Divisão" => [
+                "Corinthians",
+                "Calhau",
+                "Uni Mindelo",
+                "Estoril",
+                "São Pedro",
+                "Falcões do Norte",
+                "Ribeira Bote",
+                "Ponta d'Pom",
             ],
-            "Premier League" => [
-                "Manchester United",
-                "Liverpool",
-                "Chelsea",
-                "Arsenal",
-                "Manchester City",
-            ],
-            "La Liga" => [
-                "Barcelona",
-                "Real Madrid",
-                "Atletico Madrid",
-                "Sevilla",
-                "Valencia",
-            ],
-            "Serie A" => [
-                "Juventus",
-                "AC Milan",
-                "Inter Milan",
-                "Napoli",
-                "AS Roma",
-            ],
-            "Champions League" => [], // Add teams here if needed
+           
         ];
 
         $team_players = [
-            "Benfica" => [
-                ["name" => "Alexander Bah", "birthdate" => "1995-06-18"],
-                ["name" => "João Mário", "birthdate" => "1993-01-19"],
-                ["name" => "David Neres", "birthdate" => "1997-03-03"],
-                ["name" => "Orkun Kökçü", "birthdate" => "2000-12-25"],
-                ["name" => "Fredrik Aursnes", "birthdate" => "1995-12-10"],
+            "Mindelense" => [
+                ["name" => "Guga Sousa", "birthdate" => "1993-11-15"],
+                ["name" => "Airton Lopes", "birthdate" => "1996-06-19"],
+                ["name" => "Manuel Dias", "birthdate" => "1997-10-02"],
+                ["name" => "Flavio Martins", "birthdate" => "1989-11-22"],
+                ["name" => "Miguel Da Cruz", "birthdate" => "1995-03-03"],
             ],
-            "Porto" => [
-                ["name" => "Diogo Costa", "birthdate" => "1999-09-24"],
-                ["name" => "Pepe", "birthdate" => "1982-02-26"],
-                ["name" => "Otávio", "birthdate" => "1995-02-09"],
-                ["name" => "Evanilson", "birthdate" => "1999-01-05"],
-                ["name" => "Mateus Uribe", "birthdate" => "1991-03-21"],
+            "Derby" => [
+                ["name" => "Nuno Rocha", "birthdate" => "1993-11-15"],
+                ["name" => "Day Gomes", "birthdate" => "1996-06-19"],
+                ["name" => "Kevin Lima", "birthdate" => "1997-10-02"],
+                ["name" => "Kelton Silva", "birthdate" => "1989-11-22"],
+                ["name" => "Kenny Brantes", "birthdate" => "1995-03-03"],
             ],
-            "Sporting CP" => [
-                ["name" => "Antonio Adán", "birthdate" => "1987-05-13"],
-                ["name" => "Sebastián Coates", "birthdate" => "1990-10-07"],
-                ["name" => "Pedro Gonçalves", "birthdate" => "1998-06-28"],
-                ["name" => "Paulinho", "birthdate" => "1992-11-09"],
-                ["name" => "Manuel Ugarte", "birthdate" => "2001-04-11"],
+            "Académica do Mindelo" => [
+                ["name" => "Nuno Livramento", "birthdate" => "1993-11-15"],
+                ["name" => "Dario Miguel", "birthdate" => "1996-06-19"],
+                ["name" => "Luis CArlos", "birthdate" => "1997-10-02"],
+                ["name" => "Luis Fortes", "birthdate" => "1989-11-22"],
+                ["name" => "Garry Helton", "birthdate" => "1995-03-03"],
             ],
-            "Braga" => [
-                ["name" => "Matheus Magalhães", "birthdate" => "1992-03-10"],
-                ["name" => "Ricardo Horta", "birthdate" => "1994-09-15"],
-                ["name" => "Al Musrati", "birthdate" => "1996-04-25"],
-                ["name" => "Abel Ruiz", "birthdate" => "2000-01-28"],
-                ["name" => "Sikou Niakaté", "birthdate" => "1999-07-10"],
+            "Batuque" => [
+                ["name" => "Helton Gomes", "birthdate" => "1993-11-15"],
+                ["name" => "Gilberto Dias", "birthdate" => "1996-06-19"],
+                ["name" => "Waldir Rocha", "birthdate" => "1997-10-02"],
+                ["name" => "Valdir Alves", "birthdate" => "1989-11-22"],
+                ["name" => "Renato Lopes", "birthdate" => "1995-03-03"],
             ],
-            "Belenenses" => [
-                ["name" => "João Monteiro", "birthdate" => "1997-08-15"],
-                ["name" => "Sandro Semedo", "birthdate" => "1996-12-01"],
-                ["name" => "Miguel Rosa", "birthdate" => "1989-01-13"],
-                ["name" => "Diogo Pacheco", "birthdate" => "1995-07-04"],
-                ["name" => "Gonçalo Tavares", "birthdate" => "1999-05-22"],
+            "Amarante" => [
+                ["name" => "Izneider Gomes", "birthdate" => "1993-11-15"],
+                ["name" => "Jeff Preston", "birthdate" => "1996-06-19"],
+                ["name" => "Ruben Tavares", "birthdate" => "1997-10-02"],
+                ["name" => "Junior Felgueiras", "birthdate" => "1989-11-22"],
+                ["name" => "Renato Lucio", "birthdate" => "1995-03-03"],
             ],
-            "Manchester United" => [
-                ["name" => "Bruno Fernandes", "birthdate" => "1994-09-08"],
-                ["name" => "Marcus Rashford", "birthdate" => "1997-10-31"],
-                ["name" => "Raphaël Varane", "birthdate" => "1993-04-25"],
-                ["name" => "Casemiro", "birthdate" => "1992-02-23"],
-                ["name" => "Antony", "birthdate" => "2000-02-24"],
+            "Farense" => [
+                ["name" => "Lucio Diamante", "birthdate" => "1993-11-15"],
+                ["name" => "Luciano Lopes", "birthdate" => "1996-06-19"],
+                ["name" => "Leonardo Lima", "birthdate" => "1997-10-02"],
+                ["name" => "Djo Manuel", "birthdate" => "1989-11-22"],
+                ["name" => "Dji Helton", "birthdate" => "1995-03-03"],
             ],
-            "Liverpool" => [
-                ["name" => "Mohamed Salah", "birthdate" => "1992-06-15"],
-                ["name" => "Alisson Becker", "birthdate" => "1992-10-02"],
-                ["name" => "Virgil van Dijk", "birthdate" => "1991-07-08"],
-                ["name" => "Trent Alexander-Arnold", "birthdate" => "1998-10-07"],
-                ["name" => "Diogo Jota", "birthdate" => "1996-12-04"],
+            "Castilho" => [
+                ["name" => "Vala Gomes", "birthdate" => "1993-11-15"],
+                ["name" => "Austelino Felgueiras", "birthdate" => "1996-06-19"],
+                ["name" => "Djack Costa", "birthdate" => "1997-10-02"],
+                ["name" => "Natalino Tavares", "birthdate" => "1989-11-22"],
+                ["name" => "Enrique Gomes", "birthdate" => "1995-03-03"],
             ],
-            "Chelsea" => [
-                ["name" => "Thiago Silva", "birthdate" => "1984-09-22"],
-                ["name" => "Enzo Fernández", "birthdate" => "2001-01-17"],
-                ["name" => "Raheem Sterling", "birthdate" => "1994-12-08"],
-                ["name" => "Reece James", "birthdate" => "1999-12-08"],
-                ["name" => "Noni Madueke", "birthdate" => "2002-03-10"],
+            "Salamansa" => [
+                ["name" => "Puntuck Alvio", "birthdate" => "1993-11-15"],
+                ["name" => "Nanny Cruz", "birthdate" => "1996-06-19"],
+                ["name" => "Nany Freitas", "birthdate" => "1997-10-02"],
+                ["name" => "Nivaldo Pereira", "birthdate" => "1989-11-22"],
+                ["name" => "Kiro Gomes", "birthdate" => "1995-03-03"],
             ],
-            "Arsenal" => [
-                ["name" => "Bukayo Saka", "birthdate" => "2001-09-05"],
-                ["name" => "Martin Ødegaard", "birthdate" => "1998-12-17"],
-                ["name" => "Gabriel Jesus", "birthdate" => "1997-04-03"],
-                ["name" => "Declan Rice", "birthdate" => "1999-01-14"],
-                ["name" => "Aaron Ramsdale", "birthdate" => "1998-05-14"],
+            "Corinthians" => [
+                ["name" => "Bauss Lima", "birthdate" => "1993-11-15"],
+                ["name" => "Pastor Pires", "birthdate" => "1996-06-19"],
+                ["name" => "Bruno Verissimo", "birthdate" => "1997-10-02"],
+                ["name" => "Ediven Pires", "birthdate" => "1989-11-22"],
+                ["name" => "Guta Pires", "birthdate" => "1995-03-03"],
             ],
-            "Manchester City" => [
-                ["name" => "Kevin De Bruyne", "birthdate" => "1991-06-28"],
-                ["name" => "Erling Haaland", "birthdate" => "2000-07-21"],
-                ["name" => "Phil Foden", "birthdate" => "2000-05-28"],
-                ["name" => "Rodri", "birthdate" => "1996-06-22"],
-                ["name" => "Rúben Dias", "birthdate" => "1997-05-14"],
+            "Calhau" => [
+                ["name" => "Rudy Rocha", "birthdate" => "1993-11-15"],
+                ["name" => "Cuin Rocha", "birthdate" => "1996-06-19"],
+                ["name" => "Maky Costa", "birthdate" => "1997-10-02"],
+                ["name" => "Edy Cruz", "birthdate" => "1989-11-22"],
+                ["name" => "Ditch Alves", "birthdate" => "1995-03-03"],
             ],
-            "Barcelona" => [
-                ["name" => "Robert Lewandowski", "birthdate" => "1988-08-21"],
-                ["name" => "Pedri", "birthdate" => "2002-11-25"],
-                ["name" => "Frenkie de Jong", "birthdate" => "1997-05-12"],
-                ["name" => "Jules Koundé", "birthdate" => "1998-11-12"],
-                ["name" => "Ilkay Gündogan", "birthdate" => "1990-10-24"],
+            "Uni Mindelo" => [
+                ["name" => "Niny Pereira", "birthdate" => "1993-11-15"],
+                ["name" => "Marcos Lopes", "birthdate" => "1996-06-19"],
+                ["name" => "Marcos Silva", "birthdate" => "1997-10-02"],
+                ["name" => "Walter Silva", "birthdate" => "1989-11-22"],
+                ["name" => "Romario Sousa", "birthdate" => "1995-03-03"],
             ],
-            "Real Madrid" => [
-                ["name" => "Vinícius Júnior", "birthdate" => "2000-07-12"],
-                ["name" => "Rodrygo", "birthdate" => "2001-01-09"],
-                ["name" => "Eduardo Camavinga", "birthdate" => "2002-11-10"],
-                ["name" => "Aurélien Tchouaméni", "birthdate" => "2000-01-27"],
-                ["name" => "David Alaba", "birthdate" => "1992-06-24"],
+            "Estoril" => [
+                ["name" => "Vadjoiss Silva", "birthdate" => "1993-11-15"],
+                ["name" => "Miguel Luis", "birthdate" => "1996-06-19"],
+                ["name" => "Maiu Gilberto", "birthdate" => "1997-10-02"],
+                ["name" => "Cuk Kelton", "birthdate" => "1989-11-22"],
+                ["name" => "Kevin Bruno", "birthdate" => "1995-03-03"],
             ],
-            "Atletico Madrid" => [
-                ["name" => "Antoine Griezmann", "birthdate" => "1991-03-21"],
-                ["name" => "Jan Oblak", "birthdate" => "1993-01-07"],
-                ["name" => "Koke", "birthdate" => "1992-01-08"],
-                ["name" => "Rodrigo de Paul", "birthdate" => "1994-05-24"],
-                ["name" => "José Giménez", "birthdate" => "1995-01-20"],
+            "São Pedro" => [
+                ["name" => "Vadi Frederico", "birthdate" => "1993-11-15"],
+                ["name" => "Gilberto Gilbratar", "birthdate" => "1996-06-19"],
+                ["name" => "Bu Jorge", "birthdate" => "1997-10-02"],
+                ["name" => "Dario Duarte", "birthdate" => "1989-11-22"],
+                ["name" => "Kiren Hugo", "birthdate" => "1995-03-03"],
             ],
-            "Sevilla" => [
-                ["name" => "Ivan Rakitić", "birthdate" => "1988-03-10"],
-                ["name" => "Youssef En-Nesyri", "birthdate" => "1997-06-01"],
-                ["name" => "Marcos Acuña", "birthdate" => "1991-10-28"],
-                ["name" => "Bono", "birthdate" => "1991-04-05"],
-                ["name" => "Jesús Navas", "birthdate" => "1985-11-21"],
+            "Falcões do Norte" => [
+                ["name" => "Papy Gomes", "birthdate" => "1993-11-15"],
+                ["name" => "Patrick Lopes", "birthdate" => "1996-06-19"],
+                ["name" => "Jorge Reis", "birthdate" => "1997-10-02"],
+                ["name" => "Juary Madureira", "birthdate" => "1989-11-22"],
+                ["name" => "Bryan Costa", "birthdate" => "1995-03-03"],
             ],
-            "Valencia" => [
-                ["name" => "José Gayà", "birthdate" => "1995-05-25"],
-                ["name" => "André Almeida", "birthdate" => "2000-05-30"],
-                ["name" => "Thierry Correia", "birthdate" => "1999-03-09"],
-                ["name" => "Hugo Duro", "birthdate" => "1999-11-10"],
-                ["name" => "Javi Guerra", "birthdate" => "2003-05-13"],
+            "Ribeira Bote" => [
+                ["name" => "Helton Orlando", "birthdate" => "1993-11-15"],
+                ["name" => "Osvaldino Queiroz", "birthdate" => "1996-06-19"],
+                ["name" => "Silvio Soares", "birthdate" => "1997-10-02"],
+                ["name" => "Manuel Morais", "birthdate" => "1989-11-22"],
+                ["name" => "Lucas David", "birthdate" => "1995-03-03"],
             ],
-            "Juventus" => [
-                ["name" => "Federico Chiesa", "birthdate" => "1997-10-25"],
-                ["name" => "Dusan Vlahovic", "birthdate" => "2000-01-28"],
-                ["name" => "Manuel Locatelli", "birthdate" => "1998-01-08"],
-                ["name" => "Wojciech Szczęsny", "birthdate" => "1990-04-18"],
-                ["name" => "Paul Pogba", "birthdate" => "1993-03-15"],
-            ],
-            "AC Milan" => [
-                ["name" => "Rafael Leão", "birthdate" => "1999-06-10"],
-                ["name" => "Mike Maignan", "birthdate" => "1995-07-03"],
-                ["name" => "Theo Hernández", "birthdate" => "1997-10-06"],
-                ["name" => "Olivier Giroud", "birthdate" => "1986-09-30"],
-                ["name" => "Sandro Tonali", "birthdate" => "2000-05-08"],
-            ],
-            "Inter Milan" => [
-                ["name" => "Lautaro Martínez", "birthdate" => "1997-08-22"],
-                ["name" => "Nicolò Barella", "birthdate" => "1997-02-07"],
-                ["name" => "Alessandro Bastoni", "birthdate" => "1999-04-13"],
-                ["name" => "Denzel Dumfries", "birthdate" => "1996-04-18"],
-                ["name" => "André Onana", "birthdate" => "1996-04-02"],
-            ],
-            "Napoli" => [
-                ["name" => "Victor Osimhen", "birthdate" => "1998-12-29"],
-                ["name" => "Khvicha Kvaratskhelia", "birthdate" => "2001-02-12"],
-                ["name" => "Piotr Zieliński", "birthdate" => "1994-05-20"],
-                ["name" => "Giovanni Di Lorenzo", "birthdate" => "1993-08-04"],
-                ["name" => "Stanislav Lobotka", "birthdate" => "1994-11-25"],
-            ],
-            "AS Roma" => [
-                ["name" => "Paulo Dybala", "birthdate" => "1993-11-15"],
-                ["name" => "Lorenzo Pellegrini", "birthdate" => "1996-06-19"],
-                ["name" => "Tammy Abraham", "birthdate" => "1997-10-02"],
-                ["name" => "Chris Smalling", "birthdate" => "1989-11-22"],
-                ["name" => "Bryan Cristante", "birthdate" => "1995-03-03"],
+            "Ponta d'Pom" => [
+                ["name" => "Henry Julio", "birthdate" => "1993-11-15"],
+                ["name" => "Eros David", "birthdate" => "1996-06-19"],
+                ["name" => "Bryan Brito", "birthdate" => "1997-10-02"],
+                ["name" => "Jandir Livramento", "birthdate" => "1989-11-22"],
+                ["name" => "Mauro Faria", "birthdate" => "1995-03-03"],
             ],
         ];
 
@@ -254,77 +211,80 @@ trait DatabaseSeederTrait {
     protected function seed_competitons_teams_and_results() {
         $this->seed_competitions_and_teams();
 
-        $portuguese_league_id = Competition::where('name', 'Liga Portuguesa')->first()->id;
-        $premier_league_id = Competition::where('name', 'Premier League')->first()->id;
+        $sv_premier_league = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
+        $sv_second_league = Competition::where('name', 'Campeonato de São Vicente - 2ª Divisão')->first()->id;
 
         $season_id = Season::where('year', '24/25')->first()->id;
 
-        // get premier league teams
-        $man_utd = Team::where('name', 'Manchester United')->first();
-        $man_city = Team::where('name', 'Manchester City')->first();
-        $liverpool = Team::where('name', 'Liverpool')->first();
+        // get sv premier league teams
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
+        $amarante = Team::where('name', 'Amarante')->first();
 
-        // get portuguese league teams
-        $sporting = Team::where('name', 'Sporting')->first();
-        $braga = Team::where('name', 'Sporting Braga')->first();
-        $benfica = Team::where('name', 'Benfica')->first();
-        $porto = Team::where('name', 'Porto')->first();
+        // get sv second league teams
+        $uni_mindelo = Team::where('name', 'Uni Mindelo')->first();
+        $estoril = Team::where('name', 'Estoril')->first();
+        $calhau = Team::where('name', 'Calhau')->first();
+        $ponta_pom = Team::where('name', "Ponta d'Pom")->first();
 
-        $today_date = Carbon::today()->setTime(15, 0, 0);// e.g., today at 15:00
-        $yesterday_date = Carbon::yesterday()->setTime(10, 30, 0);
-        $tomorrow_date = Carbon::tomorrow()->setTime(9, 0, 0);
+        $pl_today_date = Carbon::today()->setTime(16, 0, 0);// e.g., today at 16:00
+        $sl_today_date_1 = Carbon::today()->setTime(10, 0, 0); 
+        $sl_today_date_2 = Carbon::today()->setTime(12, 0, 0);
+        $sl_yesterday_date = Carbon::yesterday()->setTime(12, 0, 0);
+        $pl_yesterday_date = Carbon::yesterday()->setTime(16, 0, 0);
+        $sl_tomorrow_date_1 = Carbon::tomorrow()->setTime(10, 0, 0);
+        $pl_tomorrow_date_1 = Carbon::tomorrow()->setTime(14, 0, 0);
 
         $yesterday_pl_game_1 = Game::factory()->create([
-            'date' => $yesterday_date,
-            'location' => 'Eithad Stadium',
+            'date' => $pl_yesterday_date,
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
-            'competition_id' => $premier_league_id,
+            'competition_id' => $sv_second_league,
         ]);
-        $yesterday_lpt_game_1 = Game::factory()->create([
-            'date' => $yesterday_date,
-            'location' => 'Estádio Do Dragão',
+        $yesterday_sl_game_1 = Game::factory()->create([
+            'date' => $sl_yesterday_date,
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
-            'competition_id' => $portuguese_league_id
+            'competition_id' => $sv_premier_league
         ]);
 
         $today_pl_game_1 = Game::factory()->create([
-            'date' => $today_date,
-            'location' => 'Old Trafford',
+            'date' => $pl_today_date,
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
-            'competition_id' => $premier_league_id,
+            'competition_id' => $sv_second_league,
         ]);
-        $today_lpt_game_1 = Game::factory()->create([
-            'date' => $today_date,
-            'location' => 'Estádio Municipal de Braga',
+        $today_sl_game_1 = Game::factory()->create([
+            'date' => $sl_today_date_1,
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
-            'competition_id' => $portuguese_league_id
+            'competition_id' => $sv_premier_league
         ]);
-        $today_lpt_game_2 = Game::factory()->create([
-            'date' => $today_date,
-            'location' => 'Estádio da Luz',
+        $today_sl_game_2 = Game::factory()->create([
+            'date' => $sl_today_date_2,
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
-            'competition_id' => $portuguese_league_id
+            'competition_id' => $sv_premier_league
         ]);
 
         $tomorrow_pl_game_1 = Game::factory()->create([
-            'date' => $tomorrow_date,
-            'location' => 'Anfield',
+            'date' => $pl_tomorrow_date_1,
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
-            'competition_id' => $premier_league_id,
+            'competition_id' => $sv_second_league,
         ]);
-        $tomorrow_lpt_game_1 = Game::factory()->create([
-            'date' => $tomorrow_date,
-            'location' => 'Estádio Municipal de Braga',
+        $tomorrow_sl_game_1 = Game::factory()->create([
+            'date' => $sl_tomorrow_date_1,
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
-            'competition_id' => $portuguese_league_id
+            'competition_id' => $sv_premier_league
         ]);
 
-        
-        // add players to today_pl_game_1 --> Man Utd vs Man City
-        $this->seed_players_to_game($man_utd->players, $today_pl_game_1);
-        $this->seed_players_to_game($man_city->players, $today_pl_game_1);
+        // add players to today_pl_game_1 --> Mindelense vs Derby
+        $this->seed_players_to_game($mindelense->players, $today_pl_game_1);
+        $this->seed_players_to_game($derby->players, $today_pl_game_1);
 
-        // events of today_pl_game_1 --> Man Utd vs Man City
+        // events of today_pl_game_1 --> Mindelense vs Derby
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => EventType::INITIAL_WHISTLE->value,
@@ -333,64 +293,64 @@ trait DatabaseSeederTrait {
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'foul',
-            'player_id' => $man_utd->players->where('name', 'Bruno Fernandes')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Guga Sousa')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 10,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'foul',
-            'player_id' => $man_city->players->where('name', 'Rodri')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Nuno Rocha')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 19,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'foul',
-            'player_id' => $man_city->players->where('name', 'Rodri')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Nuno Rocha')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 22,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'yellow card',
-            'player_id' => $man_city->players->where('name', 'Rodri')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Nuno Rocha')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 22,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'goal',
-            'player_id' => $man_utd->players->where('name', 'Marcus Rashford')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Airton Lopes')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 26,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'assist',
-            'player_id' => $man_utd->players->where('name', 'Bruno Fernandes')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Guga Sousa')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 26,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'goal',
-            'player_id' => $man_city->players->where('name', 'Rodri')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Nuno Rocha')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 35,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'foul',
-            'player_id' => $man_utd->players->where('name', 'Casemiro')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Flavio Martins')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 40,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'goal',
-            'player_id' => $man_city->players->where('name', 'Erling Haaland')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Day Gomes')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 46,
         ]);
         Event::create([
@@ -401,64 +361,64 @@ trait DatabaseSeederTrait {
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'goal',
-            'player_id' => $man_city->players->where('name', 'Rúben Dias')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Kevin Lima')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 50,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'assist',
-            'player_id' => $man_city->players->where('name', 'Kevin De Bruyne')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Kenny Brantes')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 50,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'subbing off',
-            'player_id' => $man_utd->players->where('name', 'Casemiro')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Flavio Martins')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 60,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'subbing in',
-            'player_id' => $man_utd->players->where('name', 'Antony')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Manuel Dias')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 60,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'subbing off',
-            'player_id' => $man_city->players->where('name', 'Kevin De Bruyne')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Kenny Brantes')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 68,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'subbing in',
-            'player_id' => $man_city->players->where('name', 'Phil Foden')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Kelton Silva')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 68,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'goal',
-            'player_id' => $man_city->players->where('name', 'Erling Haaland')->first()->id,
-            'team_id' => $man_city->id,
+            'player_id' => $derby->players->where('name', 'Day Gomes')->first()->id,
+            'team_id' => $derby->id,
             'minute' => 89,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'foul',
-            'player_id' => $man_utd->players->where('name', 'Raphaël Varane')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Miguel Da Cruz')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 90,
         ]);
         Event::create([
             'game_id' => $today_pl_game_1->id,
             'event_type' => 'red card',
-            'player_id' => $man_utd->players->where('name', 'Raphaël Varane')->first()->id,
-            'team_id' => $man_utd->id,
+            'player_id' => $mindelense->players->where('name', 'Miguel Da Cruz')->first()->id,
+            'team_id' => $mindelense->id,
             'minute' => 90,
         ]);
         Event::create([
@@ -467,56 +427,80 @@ trait DatabaseSeederTrait {
             'minute' => 94,
         ]);
 
+        // events of today today_sl_game_1 --> Estoril vs Uni Mindelo
+        Event::create([
+            'game_id' => $today_sl_game_1->id,
+            'event_type' => EventType::INITIAL_WHISTLE->value,
+            'minute' => 0,
+        ]);
+        Event::create([
+            'game_id' => $today_sl_game_1->id,
+            'event_type' => EventType::FINAL_WHISTLE->value,
+            'minute' => 96,
+        ]);
+
+        // events of today today_sl_game_1 --> Calhau vs Ponta Pom
+        Event::create([
+            'game_id' => $today_sl_game_2->id,
+            'event_type' => EventType::INITIAL_WHISTLE->value,
+            'minute' => 0,
+        ]);
+        Event::create([
+            'game_id' => $today_sl_game_2->id,
+            'event_type' => EventType::FINAL_WHISTLE->value,
+            'minute' => 93,
+        ]);
+
         Result::create([
             'game_id' => $yesterday_pl_game_1->id,
-            'home_team_id' => $man_city->id,
-            'away_team_id' => $liverpool->id,
+            'home_team_id' => $derby->id,
+            'away_team_id' => $amarante->id,
             'home_score' => 2,
             'away_score' => 2,
         ]);
 
         Result::create([
-            'game_id' => $yesterday_lpt_game_1->id,
-            'home_team_id' => $porto->id,
-            'away_team_id' => $sporting->id,
+            'game_id' => $yesterday_sl_game_1->id,
+            'home_team_id' => $ponta_pom->id,
+            "away_team_id" => $uni_mindelo->id,
             'home_score' => 0,
             'away_score' => 2,
         ]);
 
         Result::create([
             'game_id' => $today_pl_game_1->id,
-            'home_team_id' => $man_utd->id,
-            'away_team_id' => $man_city->id,
+            'home_team_id' => $mindelense->id,
+            'away_team_id' => $derby->id,
             'home_score' => 1,
             'away_score' => 4,
         ]);
 
         Result::create([
-            'game_id' => $today_lpt_game_1->id,
-            'home_team_id' => $braga->id,
-            'away_team_id' => $sporting->id,
+            'game_id' => $today_sl_game_1->id,
+            'home_team_id' => $estoril->id,
+            'away_team_id' => $uni_mindelo->id,
             'home_score' => 2,
             'away_score' => 5,
         ]);
 
         Result::create([
-            'game_id' => $today_lpt_game_2->id,
-            'home_team_id' => $benfica->id,
-            'away_team_id' => $porto->id,
-            'home_score' => 4,
+            'game_id' => $today_sl_game_2->id,
+            'home_team_id' => $calhau->id,
+            'away_team_id' => $ponta_pom->id,
+            "home_score" => 4,
             'away_score' => 4,
         ]);
 
         Result::create([
             'game_id' => $tomorrow_pl_game_1->id,
-            'home_team_id' => $liverpool->id,
-            'away_team_id' => $man_utd->id,
+            'home_team_id' => $amarante->id,
+            'away_team_id' => $mindelense->id,
         ]);
 
         Result::create([
-            'game_id' => $tomorrow_lpt_game_1->id,
-            'home_team_id' => $braga->id,
-            'away_team_id' => $benfica->id,
+            'game_id' => $tomorrow_sl_game_1->id,
+            'home_team_id' => $estoril->id,
+            'away_team_id' => $calhau->id,
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,8 +6,8 @@ use App\Http\Controllers\GameEventController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/games', [GameController::class, 'index']);
+Route::get('/games/{game_id}', [GameController::class, 'get_one']);
 
 Route::get('/games/{game_id}/events', [GameEventController::class, 'index']);
-
 // this route will be private
 Route::post('/games/{game_id}/events', [GameEventController::class, 'store']);

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -2,6 +2,10 @@
 
 use Illuminate\Support\Facades\Broadcast;
 
-Broadcast::channel('game-live', function () {
+Broadcast::channel('games-live', function () {
     return true;
+});
+
+Broadcast::channel('game-live.{gameId}', function ($gameId) {
+    return true; 
 });

--- a/tests/Feature/EventTest.php
+++ b/tests/Feature/EventTest.php
@@ -30,29 +30,29 @@ class EventTest extends TestCase
 
     #[Test]
     public function it_should_successful_create_a_game_event_without_player_id_and_team_id(): void {
-        $league_id = Competition::where('name', 'Serie A')->first()->id;
+        $league_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
         $season_id = Season::where('year', '24/25')->first()->id;
 
-        $napoli = Team::where('name', 'Napoli')->first();
-        $roma = Team::where('name', 'AS Roma')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
 
         $today_date = Carbon::today()->setTime(15, 0, 0);
 
         $game = Game::create([
             'date' => $today_date,
-            'location' => 'Stadio Olimpico di Roma',
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
             'competition_id' => $league_id,
         ]);
 
         Result::create([
             'game_id' => $game->id,
-            'home_team_id' => $roma->id,
-            'away_team_id' => $napoli->id,
+            'home_team_id' => $derby->id,
+            'away_team_id' => $mindelense->id,
         ]);
 
-        $this->seed_players_to_game($napoli->players, $game);
-        $this->seed_players_to_game($roma->players, $game);
+        $this->seed_players_to_game($mindelense->players, $game);
+        $this->seed_players_to_game($derby->players, $game);
 
         $response = $this->postJson(
             "/api/games/$game->id/events",
@@ -71,39 +71,39 @@ class EventTest extends TestCase
 
     #[Test]
     public function it_should_successful_create_a_game_event_with_player_id_and_team_id(): void {
-        $league_id = Competition::where('name', 'Serie A')->first()->id;
+        $league_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
         $season_id = Season::where('year', '24/25')->first()->id;
 
-        $napoli = Team::where('name', 'Napoli')->first();
-        $roma = Team::where('name', 'AS Roma')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
 
         $today_date = Carbon::today()->setTime(18, 0, 0);
 
         $game = Game::create([
             'date' => $today_date,
-            'location' => 'Stadio Olimpico di Roma',
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
             'competition_id' => $league_id,
         ]);
 
         Result::create([
             'game_id' => $game->id,
-            'home_team_id' => $roma->id,
-            'away_team_id' => $napoli->id,
+            'home_team_id' => $derby->id,
+            'away_team_id' => $mindelense->id,
         ]);
 
-        $this->seed_players_to_game($napoli->players, $game);
-        $this->seed_players_to_game($roma->players, $game);
+        $this->seed_players_to_game($mindelense->players, $game);
+        $this->seed_players_to_game($derby->players, $game);
 
-        $dybala = $game->players->firstWhere('name', 'Paulo Dybala');
+        $nuno_rocha = $game->players->firstWhere('name', 'Nuno Rocha');
 
         $response = $this->postJson(
             "/api/games/$game->id/events",
             [
                 'event_type' => 'goal',
                 'minute' => 10,
-                'team_id' => $roma->id,
-                'player_id' => $dybala->id
+                'team_id' => $derby->id,
+                'player_id' => $nuno_rocha->id
             ]
         );
 
@@ -137,31 +137,31 @@ class EventTest extends TestCase
 
     #[Test]
     public function it_should_return_status_code_422_when_the_event_type_is_null(): void {
-        $league_id = Competition::where('name', 'Serie A')->first()->id;
+        $league_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
         $season_id = Season::where('year', '24/25')->first()->id;
 
-        $napoli = Team::where('name', 'Napoli')->first();
-        $roma = Team::where('name', 'AS Roma')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
 
         $today_date = Carbon::today()->setTime(15, 0, 0);
 
         $game = Game::create([
             'date' => $today_date,
-            'location' => 'Stadio Olimpico di Roma',
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
             'competition_id' => $league_id,
         ]);
 
         Result::create([
             'game_id' => $game->id,
-            'home_team_id' => $roma->id,
-            'away_team_id' => $napoli->id,
+            'home_team_id' => $derby->id,
+            'away_team_id' => $mindelense->id,
         ]);
 
-        $this->seed_players_to_game($napoli->players, $game);
-        $this->seed_players_to_game($roma->players, $game);
+        $this->seed_players_to_game($mindelense->players, $game);
+        $this->seed_players_to_game($derby->players, $game);
 
-        $dybala = $game->players->firstWhere('name', 'Paulo Dybala');
+        $nuno_rocha = $game->players->firstWhere('name', 'Nuno Rocha');
 
         $expected_response = [
             "message" => "The event type field is required."
@@ -172,8 +172,8 @@ class EventTest extends TestCase
             [
                 'event_type' => null,
                 'minute' => 10,
-                'team_id' => $roma->id,
-                'player_id' => $dybala->id
+                'team_id' => $derby->id,
+                'player_id' => $nuno_rocha->id
             ]
         );
 
@@ -184,29 +184,29 @@ class EventTest extends TestCase
 
     #[Test]
     public function it_should_return_status_code_422_when_the_team_id_is_present_but_the_player_id_not(): void {
-        $league_id = Competition::where('name', 'Serie A')->first()->id;
+        $league_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
         $season_id = Season::where('year', '24/25')->first()->id;
 
-        $napoli = Team::where('name', 'Napoli')->first();
-        $roma = Team::where('name', 'AS Roma')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
 
         $today_date = Carbon::today()->setTime(15, 0, 0);
 
         $game = Game::create([
             'date' => $today_date,
-            'location' => 'Stadio Olimpico di Roma',
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
             'competition_id' => $league_id,
         ]);
 
         Result::create([
             'game_id' => $game->id,
-            'home_team_id' => $roma->id,
-            'away_team_id' => $napoli->id,
+            'home_team_id' => $derby->id,
+            'away_team_id' => $mindelense->id,
         ]);
 
-        $this->seed_players_to_game($napoli->players, $game);
-        $this->seed_players_to_game($roma->players, $game);
+        $this->seed_players_to_game($mindelense->players, $game);
+        $this->seed_players_to_game($derby->players, $game);
 
         $expected_response = [
             "message" => "The team_id must be null when player_id is null."
@@ -217,7 +217,7 @@ class EventTest extends TestCase
             [
                 'event_type' => 'red card',
                 'minute' => 10,
-                'team_id' => $roma->id,
+                'team_id' => $derby->id,
                 'player_id' => null
             ]
         );
@@ -229,31 +229,31 @@ class EventTest extends TestCase
 
     #[Test]
     public function it_should_return_status_code_422_when_the_player_id_is_present_but_the_team_id_not(): void {
-        $league_id = Competition::where('name', 'Serie A')->first()->id;
+        $league_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
         $season_id = Season::where('year', '24/25')->first()->id;
 
-        $napoli = Team::where('name', 'Napoli')->first();
-        $roma = Team::where('name', 'AS Roma')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
 
         $today_date = Carbon::today()->setTime(15, 0, 0);
 
         $game = Game::create([
             'date' => $today_date,
-            'location' => 'Stadio Olimpico di Roma',
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
             'competition_id' => $league_id,
         ]);
 
         Result::create([
             'game_id' => $game->id,
-            'home_team_id' => $roma->id,
-            'away_team_id' => $napoli->id,
+            'home_team_id' => $derby->id,
+            'away_team_id' => $mindelense->id,
         ]);
 
-        $this->seed_players_to_game($napoli->players, $game);
-        $this->seed_players_to_game($roma->players, $game);
+        $this->seed_players_to_game($mindelense->players, $game);
+        $this->seed_players_to_game($derby->players, $game);
 
-        $dybala = $game->players->firstWhere('name', 'Paulo Dybala');
+        $nuno_rocha = $game->players->firstWhere('name', 'Nuno Rocha');
 
         $expected_response = [
             "message" => "The player_id must be null when team_id is null."
@@ -265,7 +265,7 @@ class EventTest extends TestCase
                 'event_type' => 'assist',
                 'minute' => 10,
                 'team_id' => null,
-                'player_id' => $dybala->id
+                'player_id' => $nuno_rocha->id
             ]
         );
 
@@ -276,31 +276,31 @@ class EventTest extends TestCase
 
     #[Test]
     public function it_should_return_status_code_422_when_the_player_not_belongs_to_the_team(): void {
-        $league_id = Competition::where('name', 'Serie A')->first()->id;
+        $league_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
         $season_id = Season::where('year', '24/25')->first()->id;
 
-        $napoli = Team::where('name', 'Napoli')->first();
-        $roma = Team::where('name', 'AS Roma')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
 
         $today_date = Carbon::today()->setTime(15, 0, 0);
 
         $game = Game::create([
             'date' => $today_date,
-            'location' => 'Stadio Olimpico di Roma',
+            'location' => 'Adérito Sena',
             'season_id' => $season_id,
             'competition_id' => $league_id,
         ]);
 
         Result::create([
             'game_id' => $game->id,
-            'home_team_id' => $roma->id,
-            'away_team_id' => $napoli->id,
+            'home_team_id' => $derby->id,
+            'away_team_id' => $mindelense->id,
         ]);
 
-        $this->seed_players_to_game($napoli->players, $game);
-        $this->seed_players_to_game($roma->players, $game);
+        $this->seed_players_to_game($mindelense->players, $game);
+        $this->seed_players_to_game($derby->players, $game);
 
-        $dybala = $game->players->firstWhere('name', 'Paulo Dybala');
+        $nuno_rocha = $game->players->firstWhere('name', 'Nuno Rocha');
 
         $expected_response = [
             "message" => "The selected player does not belong to the specified team."
@@ -311,8 +311,8 @@ class EventTest extends TestCase
             [
                 'event_type' => 'yellow card',
                 'minute' => 10,
-                'team_id' => $napoli->id,
-                'player_id' => $dybala->id
+                'team_id' => $mindelense->id,
+                'player_id' => $nuno_rocha->id
             ]
         );
 

--- a/tests/Feature/GameTest.php
+++ b/tests/Feature/GameTest.php
@@ -28,69 +28,125 @@ class GameTest extends TestCase {
     }
 
     #[Test]
+    public function it_should_get_a_game_by_id(): void {
+        $game_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::today()->setTime(16, 0, 0))
+            ->first()->id;
+
+        $competition_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
+        
+        $mindelense_id = Team::where('name', 'Mindelense')->first()->id;
+        $derby_id = Team::where('name', 'Derby')->first()->id;
+
+        $expected_response = [
+            "competition_id" => $competition_id,
+            "competition_name" => "Campeonato de São Vicente - 1ª Divisão",
+            "id" => $game_id,
+            "date" => Carbon::today()->setTime(16, 0, 0)->format('Y-m-d H:i:s'),
+            "location" => "Adérito Sena",
+            "home_team_id" => $mindelense_id,
+            "home_team_name" => "Mindelense",
+            "away_team_id" => $derby_id,
+            "away_team_name" => "Derby",
+            "home_score" => 1,
+            "away_score" => 4,
+            "started" => true,
+            "ongoing" => false,
+            "finished" => true,
+        ];
+
+        $response = $this->get("/api/games/$game_id");
+        
+        $response
+            ->assertStatus(200)
+            ->assertExactJson($expected_response);
+    }
+
+    #[Test]
+    public function it_should_return_404_when_the_id_does_not_exists(): void {
+        $invalid_game_id = 'f604d182-d89b-479f-be3c-3e9e2596617c';
+    
+        $expected_response = [
+            "message" => "Game's id not found"
+        ];
+
+        $response = $this->get("/api/games/$invalid_game_id");
+        
+        $response
+            ->assertStatus(404)
+            ->assertExactJson($expected_response);
+    }
+
+    #[Test]
     public function it_should_get_all_today_games_grouped_by_competitions(): void {
-        $pl_competition_id = Competition::where('name', 'Premier League')->first()->id;
-        $lpt_competition_id = Competition::where('name', 'Liga Portuguesa')->first()->id;
+        $pl_competition_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
+        $sl_competition_id = Competition::where('name', 'Campeonato de São Vicente - 2ª Divisão')->first()->id;
 
-        $today_lpt_game_1_id = Game::where('location', 'Estádio Municipal de Braga')->first()->id;
-        $today_lpt_game_2_id = Game::where('location', 'Estádio da Luz')->first()->id;
-        $today_pl_game_1_id = Game::where('location', 'Old Trafford')->first()->id;
+        $today_sl_game_1_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::today()->setTime(10, 0, 0))
+            ->first()->id;
+        $today_sl_game_2_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::today()->setTime(12, 0, 0))
+            ->first()->id;
+        $today_pl_game_1_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::today()->setTime(16, 0, 0))
+            ->first()->id;
 
-        $man_utd = Team::where('name', 'Manchester United')->first();
-        $man_city = Team::where('name', 'Manchester City')->first();
-        $sporting = Team::where('name', 'Sporting')->first();
-        $braga = Team::where('name', 'Sporting Braga')->first();
-        $benfica = Team::where('name', 'Benfica')->first();
-        $porto = Team::where('name', 'Porto')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
+        $uni_mindelo = Team::where('name', 'Uni Mindelo')->first();
+        $estoril = Team::where('name', 'Estoril')->first();
+        $calhau = Team::where('name', 'Calhau')->first();
+        $ponta = Team::where('name', "Ponta d'Pom")->first();
 
         $expected_response = [
             [
-                'id' => $lpt_competition_id,
-                'competition_name' => 'Liga Portuguesa',
+                'id' => $pl_competition_id,
+                'competition_name' => 'Campeonato de São Vicente - 1ª Divisão',
                 'games' => [
                     [
-                        'id' => $today_lpt_game_1_id,
-                        'date' => Carbon::today()->setTime(15, 0, 0)->format('Y-m-d\TH:i:s'),
-                        'location' => 'Estádio Municipal de Braga',
-                        'home_team_id' => $braga->id,
-                        'home_team_name' => 'Sporting Braga',
-                        'away_team_id' => $sporting->id,
-                        'away_team_name' => 'Sporting',
-                        'home_score' => 2,
-                        'away_score' => 5,
-                        'started' => false,
-                        'ongoing' => false,
-                        'finished' => false,
-                    ],
-                    [
-                        'id' => $today_lpt_game_2_id,
-                        'date' => Carbon::today()->setTime(15, 0, 0)->format('Y-m-d\TH:i:s'),
-                        'location' => 'Estádio da Luz',
-                        'home_team_id' => $benfica->id,
-                        'home_team_name' => 'Benfica',
-                        'away_team_id' => $porto->id,
-                        'away_team_name' => 'Porto',
-                        'home_score' => 4,
+                        'id' => $today_pl_game_1_id,
+                        'date' => Carbon::today()->setTime(16, 0, 0)->format('Y-m-d\TH:i:s'),
+                        'location' => 'Adérito Sena',
+                        'home_team_id' => $mindelense->id,
+                        'home_team_name' => 'Mindelense',
+                        'away_team_id' => $derby->id,
+                        'away_team_name' => 'Derby',
+                        'home_score' => 1,
                         'away_score' => 4,
-                        'started' => false,
+                        'started' => true,
                         'ongoing' => false,
-                        'finished' => false,
+                        'finished' => true,
                     ]
                 ]
             ],
             [
-                'id' => $pl_competition_id,
-                'competition_name' => 'Premier League',
+                'id' => $sl_competition_id,
+                'competition_name' => 'Campeonato de São Vicente - 2ª Divisão',
                 'games' => [
                     [
-                        'id' => $today_pl_game_1_id,
-                        'date' => Carbon::today()->setTime(15, 0, 0)->format('Y-m-d\TH:i:s'),
-                        'location' => 'Old Trafford',
-                        'home_team_id' => $man_utd->id,
-                        'home_team_name' => 'Manchester United',
-                        'away_team_id' => $man_city->id,
-                        'away_team_name' => 'Manchester City',
-                        'home_score' => 1,
+                        'id' => $today_sl_game_1_id,
+                        'date' => Carbon::today()->setTime(10, 0, 0)->format('Y-m-d\TH:i:s'),
+                        'location' => 'Adérito Sena',
+                        'home_team_id' => $estoril->id,
+                        'home_team_name' => 'Estoril',
+                        'away_team_id' => $uni_mindelo->id,
+                        'away_team_name' => 'Uni Mindelo',
+                        'home_score' => 2,
+                        'away_score' => 5,
+                        'started' => true,
+                        'ongoing' => false,
+                        'finished' => true,
+                    ],
+                    [
+                        'id' => $today_sl_game_2_id,
+                        'date' => Carbon::today()->setTime(12, 0, 0)->format('Y-m-d\TH:i:s'),
+                        'location' => 'Adérito Sena',
+                        'home_team_id' => $calhau->id,
+                        'home_team_name' => 'Calhau',
+                        'away_team_id' => $ponta->id,
+                        'away_team_name' => "Ponta d'Pom",
+                        'home_score' => 4,
                         'away_score' => 4,
                         'started' => true,
                         'ongoing' => false,
@@ -104,12 +160,11 @@ class GameTest extends TestCase {
 
         // Convert the response JSON to an array for inspection
         $response_data = $response->json();
-
         // Check the number of competitions
         $this->assertCount(2, $response_data, 'The number of competitions should be 2.');
         // Check the number of games for each competition
-        $this->assertCount(2, $response_data[0]['games'], 'The number of games for Liga Portuguesa should be 2.');
-        $this->assertCount(1, $response_data[1]['games'], 'The number of games for Premier League should be 1.');
+        $this->assertCount(1, $response_data[0]['games'], 'The number of games for Campeonato de São Vicente - 1ª Divisão should be 1.');
+        $this->assertCount(2, $response_data[1]['games'], 'The number of games for Campeonato de São Vicente - 2ª Divisão should be 2.');
         // Assert that the response matches exactly with the expected JSON
         $response
             ->assertStatus(200)
@@ -118,56 +173,60 @@ class GameTest extends TestCase {
     
     #[Test]
     public function it_should_get_all_yesterday_games_grouped_by_competitions(): void {
-        $pl_competition_id = Competition::where('name', 'Premier League')->first()->id;
-        $lpt_competition_id = Competition::where('name', 'Liga Portuguesa')->first()->id;
+        $pl_competition_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
+        $sl_competition_id = Competition::where('name', 'Campeonato de São Vicente - 2ª Divisão')->first()->id;
 
-        $yesterday_lpt_game_1_id = Game::where('location', 'Estádio Do Dragão')->first()->id;
-        $yesterday_pl_game_1_id = Game::where('location', 'Eithad Stadium')->first()->id;
+        $yesterday_sl_game_1_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::yesterday()->setTime(12, 0, 0))
+            ->first()->id;
+        $yesterday_pl_game_1_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::yesterday()->setTime(16, 0, 0))
+            ->first()->id;
 
-        $liverpool = Team::where('name', 'Liverpool')->first();
-        $man_city = Team::where('name', 'Manchester City')->first();
-        $sporting = Team::where('name', 'Sporting')->first();
-        $porto = Team::where('name', 'Porto')->first();
+        $amarante = Team::where('name', 'Amarante')->first();
+        $derby = Team::where('name', 'Derby')->first();
+        $uni_mindelo = Team::where('name', 'Uni Mindelo')->first();
+        $ponta = Team::where('name', "Ponta d'Pom")->first();
 
         $expected_response = [
             [
-                'id' => $lpt_competition_id,
-                'competition_name' => 'Liga Portuguesa',
-                'games' => [
-                    [
-                        'id' => $yesterday_lpt_game_1_id,
-                        'date' => Carbon::yesterday()->setTime(10, 30, 0)->format('Y-m-d\TH:i:s'),
-                        'location' => 'Estádio Do Dragão',
-                        'home_team_id' => $porto->id,
-                        'home_team_name' => 'Porto',
-                        'away_team_id' => $sporting->id,
-                        'away_team_name' => 'Sporting',
-                        'home_score' => 0,
-                        'away_score' => 2,
-                        'started' => false,
-                        'ongoing' => false,
-                        'finished' => false,
-                    ],
-                ]
-            ],
-            [
                 'id' => $pl_competition_id,
-                'competition_name' => 'Premier League',
+                'competition_name' => 'Campeonato de São Vicente - 1ª Divisão',
                 'games' => [
                     [
                         'id' => $yesterday_pl_game_1_id,
-                        'date' => Carbon::yesterday()->setTime(10, 30, 0)->format('Y-m-d\TH:i:s'),
-                        'location' => 'Eithad Stadium',
-                        'home_team_id' => $man_city->id,
-                        'home_team_name' => 'Manchester City',
-                        'away_team_id' => $liverpool->id,
-                        'away_team_name' => 'Liverpool',
+                        'date' => Carbon::yesterday()->setTime(16, 0, 0)->format('Y-m-d\TH:i:s'),
+                        'location' => 'Adérito Sena',
+                        'home_team_id' => $derby->id,
+                        'home_team_name' => 'Derby',
+                        'away_team_id' => $amarante->id,
+                        'away_team_name' => 'Amarante',
                         'home_score' => 2,
                         'away_score' => 2,
                         'started' => false,
                         'ongoing' => false,
                         'finished' => false,
                     ]
+                ]
+            ],
+            [
+                'id' => $sl_competition_id,
+                'competition_name' => 'Campeonato de São Vicente - 2ª Divisão',
+                'games' => [
+                    [
+                        'id' => $yesterday_sl_game_1_id,
+                        'date' => Carbon::yesterday()->setTime(12, 0, 0)->format('Y-m-d\TH:i:s'),
+                        'location' => 'Adérito Sena',
+                        'home_team_id' => $ponta->id,
+                        'home_team_name' => "Ponta d'Pom",
+                        'away_team_id' => $uni_mindelo->id,
+                        'away_team_name' => 'Uni Mindelo',
+                        'home_score' => 0,
+                        'away_score' => 2,
+                        'started' => false,
+                        'ongoing' => false,
+                        'finished' => false,
+                    ],
                 ]
             ],
         ];
@@ -183,61 +242,61 @@ class GameTest extends TestCase {
   
     #[Test]
     public function it_should_get_all_tomorrow_games_grouped_by_competitions(): void {
-        $pl_competition_id = Competition::where('name', 'Premier League')->first()->id;
-        $lpt_competition_id = Competition::where('name', 'Liga Portuguesa')->first()->id;
+        $pl_competition_id = Competition::where('name', 'Campeonato de São Vicente - 1ª Divisão')->first()->id;
+        $sl_competition_id = Competition::where('name', 'Campeonato de São Vicente - 2ª Divisão')->first()->id;
 
-        $liverpool = Team::where('name', 'Liverpool')->first();
-        $man_utd = Team::where('name', 'Manchester United')->first();
-        $braga = Team::where('name', 'Sporting Braga')->first();
-        $benfica = Team::where('name', 'Benfica')->first();
+        $amarante = Team::where('name', 'Amarante')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $estoril = Team::where('name', 'Estoril')->first();
+        $calhau = Team::where('name', 'Calhau')->first();
 
-        $tomorrow_lpt_game_1_id = Game::where('location', 'Estádio Municipal de Braga')
-            ->where('date', Carbon::tomorrow()->setTime(9, 0, 0))
+        $tomorrow_sl_game_1_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::tomorrow()->setTime(10, 0, 0))
             ->first()->id;
 
-        $tomorrow_pl_game_1_id = Game::where('location', 'Anfield')
-            ->where('date', Carbon::tomorrow()->setTime(9, 0, 0))
+        $tomorrow_pl_game_1_id = Game::where('location', 'Adérito Sena')
+            ->where('date', Carbon::tomorrow()->setTime(14, 0, 0))
             ->first()->id;
 
         $expected_response = [
             [
-                'id' => $lpt_competition_id,
-                'competition_name' => 'Liga Portuguesa',
-                'games' => [
-                    [
-                        'id' => $tomorrow_lpt_game_1_id,
-                        'date' => Carbon::tomorrow()->setTime(9, 0, 0)->format('Y-m-d\TH:i:s'),
-                        'location' => 'Estádio Municipal de Braga',
-                        'home_team_id' => $braga->id,
-                        'home_team_name' => 'Sporting Braga',
-                        'away_team_id' => $benfica->id,
-                        'away_team_name' => 'Benfica',
-                        'home_score' => null,
-                        'away_score' => null,
-                        'started' => false,
-                        'ongoing' => false,
-                        'finished' => false,
-                    ],
-                ]
-            ],
-            [
                 'id' => $pl_competition_id,
-                'competition_name' => 'Premier League',
+                'competition_name' => 'Campeonato de São Vicente - 1ª Divisão',
                 'games' => [
                     [
                         'id' => $tomorrow_pl_game_1_id,
-                        'date' => Carbon::tomorrow()->setTime(9, 0, 0)->format('Y-m-d\TH:i:s'),
-                        'location' => 'Anfield',
-                        'home_team_id' => $liverpool->id,
-                        'home_team_name' => 'Liverpool',
-                        'away_team_id' => $man_utd->id,
-                        'away_team_name' => 'Manchester United',
+                        'date' => Carbon::tomorrow()->setTime(14, 0, 0)->format('Y-m-d\TH:i:s'),
+                        'location' => 'Adérito Sena',
+                        'home_team_id' => $amarante->id,
+                        'home_team_name' => 'Amarante',
+                        'away_team_id' => $mindelense->id,
+                        'away_team_name' => 'Mindelense',
                         'home_score' => null,
                         'away_score' => null,
                         'started' => false,
                         'ongoing' => false,
                         'finished' => false,
                     ]
+                ]
+            ],
+            [
+                'id' => $sl_competition_id,
+                'competition_name' => 'Campeonato de São Vicente - 2ª Divisão',
+                'games' => [
+                    [
+                        'id' => $tomorrow_sl_game_1_id,
+                        'date' => Carbon::tomorrow()->setTime(10, 0, 0)->format('Y-m-d\TH:i:s'),
+                        'location' => 'Adérito Sena',
+                        'home_team_id' => $estoril->id,
+                        'home_team_name' => 'Estoril',
+                        'away_team_id' => $calhau->id,
+                        'away_team_name' => 'Calhau',
+                        'home_score' => null,
+                        'away_score' => null,
+                        'started' => false,
+                        'ongoing' => false,
+                        'finished' => false,
+                    ],
                 ]
             ],
         ];
@@ -253,23 +312,23 @@ class GameTest extends TestCase {
 
     #[Test]
     public function it_should_get_all_the_events_from_a_match_grouped_by_teams(): void {
-        $man_utd = Team::where('name', 'Manchester United')->first();
-        $man_city = Team::where('name', 'Manchester City')->first();
+        $mindelense = Team::where('name', 'Mindelense')->first();
+        $derby = Team::where('name', 'Derby')->first();
 
-        $game_id = Result::where('home_team_id', $man_utd->id)
-            ->where('away_team_id', $man_city->id)
+        $game_id = Result::where('home_team_id', $mindelense->id)
+            ->where('away_team_id', $derby->id)
             ->first()->game_id;
 
-        $bruno_f_id = Player::where('name', 'Bruno Fernandes')->first()->id;
-        $rodri_id = Player::where('name', 'Rodri')->first()->id;
-        $marc_rashford_id = Player::where('name', 'Marcus Rashford')->first()->id;
-        $casemiro_id = Player::where('name', 'Casemiro')->first()->id;
-        $halland_id = Player::where('name', 'Erling Haaland')->first()->id;
-        $ruben_dias_id = Player::where('name', 'Rúben Dias')->first()->id; 
-        $de_bruyne_id = Player::where('name', 'Kevin De Bruyne')->first()->id;
-        $varane_id = Player::where('name', 'Raphaël Varane')->first()->id;
-        $antony_id = Player::where('name', 'Antony')->first()->id;
-        $foden_id = Player::where('name', 'Phil Foden')->first()->id;
+        $guga_id = Player::where('name', 'Guga Sousa')->first()->id;
+        $n_rocha_id = Player::where('name', 'Nuno Rocha')->first()->id;
+        $airton_lopes_id = Player::where('name', 'Airton Lopes')->first()->id;
+        $flav_martins_id = Player::where('name', 'Flavio Martins')->first()->id;
+        $day_gomes_id = Player::where('name', 'Day Gomes')->first()->id;
+        $kevin_lima_id = Player::where('name', 'Kevin Lima')->first()->id; 
+        $kenny_brantes_id = Player::where('name', 'Kenny Brantes')->first()->id;
+        $miguel_cruz_id = Player::where('name', 'Miguel Da Cruz')->first()->id;
+        $manuel_dias_id = Player::where('name', 'Manuel Dias')->first()->id;
+        $kelton_silva_id = Player::where('name', 'Kelton Silva')->first()->id;
 
         $expected_response = [
             [
@@ -283,74 +342,74 @@ class GameTest extends TestCase {
             [
                 'event_type' => "foul",
                 'minute' => 10,
-                'player_id' => $bruno_f_id,
-                'player_name' => "Bruno Fernandes",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $guga_id,
+                'player_name' => "Guga Sousa",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => "foul",
                 'minute' => 19,
-                'player_id' => $rodri_id,
-                'player_name' => "Rodri",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $n_rocha_id,
+                'player_name' => "Nuno Rocha",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "foul",
                 'minute' => 22,
-                'player_id' => $rodri_id,
-                'player_name' => "Rodri",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $n_rocha_id,
+                'player_name' => "Nuno Rocha",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "yellow card",
                 'minute' => 22,
-                'player_id' => $rodri_id,
-                'player_name' => "Rodri",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $n_rocha_id,
+                'player_name' => "Nuno Rocha",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "goal",
                 'minute' => 26,
-                'player_id' => $marc_rashford_id,
-                'player_name' => "Marcus Rashford",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $airton_lopes_id,
+                'player_name' => "Airton Lopes",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => "assist",
                 'minute' => 26,
-                'player_id' => $bruno_f_id,
-                'player_name' => "Bruno Fernandes",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $guga_id,
+                'player_name' => "Guga Sousa",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => "goal",
                 'minute' => 35,
-                'player_id' => $rodri_id,
-                'player_name' => "Rodri",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $n_rocha_id,
+                'player_name' => "Nuno Rocha",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "foul",
                 'minute' => 40,
-                'player_id' => $casemiro_id,
-                'player_name' => "Casemiro",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $flav_martins_id,
+                'player_name' => "Flavio Martins",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => "goal",
                 'minute' => 46,
-                'player_id' => $halland_id,
-                'player_name' => "Erling Haaland",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $day_gomes_id,
+                'player_name' => "Day Gomes",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => EventType::HALF_TIME->value,
@@ -363,74 +422,74 @@ class GameTest extends TestCase {
             [
                 'event_type' => "goal",
                 'minute' => 50,
-                'player_id' => $ruben_dias_id,
-                'player_name' => "Rúben Dias",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $kevin_lima_id,
+                'player_name' => "Kevin Lima",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "assist",
                 'minute' => 50,
-                'player_id' => $de_bruyne_id,
-                'player_name' => "Kevin De Bruyne",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $kenny_brantes_id,
+                'player_name' => "Kenny Brantes",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "subbing off",
                 'minute' => 60,
-                'player_id' => $casemiro_id,
-                'player_name' => "Casemiro",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $flav_martins_id,
+                'player_name' => "Flavio Martins",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => "subbing in",
                 'minute' => 60,
-                'player_id' => $antony_id,
-                'player_name' => "Antony",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $manuel_dias_id,
+                'player_name' => "Manuel Dias",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => "subbing off",
                 'minute' => 68,
-                'player_id' => $de_bruyne_id,
-                'player_name' => "Kevin De Bruyne",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $kenny_brantes_id,
+                'player_name' => "Kenny Brantes",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "subbing in",
                 'minute' => 68,
-                'player_id' => $foden_id,
-                'player_name' => "Phil Foden",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $kelton_silva_id,
+                'player_name' => "Kelton Silva",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "goal",
                 'minute' => 89,
-                'player_id' => $halland_id,
-                'player_name' => "Erling Haaland",
-                'team_id' => $man_city->id,
-                'team_name' => "Manchester City",
+                'player_id' => $day_gomes_id,
+                'player_name' => "Day Gomes",
+                'team_id' => $derby->id,
+                'team_name' => "Derby",
             ],
             [
                 'event_type' => "foul",
                 'minute' => 90,
-                'player_id' => $varane_id,
-                'player_name' => "Raphaël Varane",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $miguel_cruz_id,
+                'player_name' => "Miguel Da Cruz",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => "red card",
                 'minute' => 90,
-                'player_id' => $varane_id,
-                'player_name' => "Raphaël Varane",
-                'team_id' => $man_utd->id,
-                'team_name' => "Manchester United",
+                'player_id' => $miguel_cruz_id,
+                'player_name' => "Miguel Da Cruz",
+                'team_id' => $mindelense->id,
+                'team_name' => "Mindelense",
             ],
             [
                 'event_type' => EventType::FINAL_WHISTLE->value,


### PR DESCRIPTION
# API Endpoint Documentation

## 1. GET /games/:game_id route

### Purpose
Get the details of a specific game and use Laravel's event broadcasting to send updates to the `game-live.{game_id}` channel.

### Request
- **Route**: `/games/:game_id`
- **Method**: `GET`
- **Path Parameter**:
  - `:game_id` (string): The unique identifier (UUID) of the game.
- **Content Type**: `application/json`

### Response Body
```json
{
  "id": "Game ID",
  "competition_id": "ID of the competition",
  "competition_name": "Name of the competition",
  "date": "Date of the game",
  "location": "Location of the game",
  "home_team_id": "ID of the home team",
  "home_team_name": "Name of the home team",
  "away_team_id": "ID of the away team",
  "away_team_name": "Name of the away team",
  "home_score": "Number of goals scored by the home team",
  "away_score": "Number of goals scored by the away team",
  "started": "A Boolean value that indicates whether the game has already started or not",
  "ongoing": "A Boolean value that indicates whether the game is still in progress or has already concluded",
  "finished": "A Boolean value that indicates whether the game has finished or not"
}
```

### Objective
To allow the frontend get details of a game and broadcast game events during live matches, facilitating real-time updates for the viewers to stay informed about the latest actions in the game.
